### PR TITLE
Implement solvency workflow and bootstrap layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Housebidding
 
 Projet Laravel 11 minimaliste de vente aux enchères d'une maison.
+L'interface utilise Bootstrap 5 via CDN (aucune compilation n'est nécessaire).
 
 ## Installation
 
@@ -9,7 +10,6 @@ composer install
 cp .env.example .env
 php artisan key:generate
 php artisan migrate --seed
-npm install && npm run build # compilation locale de Tailwind
 ```
 
 ## Déploiement sur o2switch

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -31,6 +31,13 @@ class AdminController extends Controller
         return back();
     }
 
+    public function validateDocument(User $user)
+    {
+        $this->authorizeAdmin();
+        $user->update(['document_valide' => true]);
+        return back();
+    }
+
     private function authorizeAdmin(): void
     {
         if (Auth::guest() || Auth::user()->email !== config('mail.admin_address')) {

--- a/app/Http/Controllers/BidController.php
+++ b/app/Http/Controllers/BidController.php
@@ -16,6 +16,10 @@ class BidController extends Controller
     {
         $property = Property::first();
 
+        if (!Auth::user()->document_valide) {
+            return back()->withErrors(['document' => "Vous devez fournir un justificatif de solvabilité pour participer à l'enchère."]);
+        }
+
         if ($property->closed || $property->end_at->isPast()) {
             return back()->withErrors(['auction' => 'La vente est terminée.']);
         }

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use App\Mail\DocumentSubmitted;
+
+class DocumentController extends Controller
+{
+    public function show()
+    {
+        return view('document.upload', ['user' => Auth::user()]);
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'justificatif' => ['required', 'file', 'mimes:pdf,jpg,jpeg,png,webp'],
+        ]);
+
+        $path = $request->file('justificatif')->store('justificatifs', 'public');
+
+        $user = $request->user();
+        $user->update([
+            'justificatif_path' => $path,
+            'document_valide' => false,
+        ]);
+
+        Mail::to(config('mail.admin_address'))->send(new DocumentSubmitted($user));
+
+        return back()->with('status', 'document-submitted');
+    }
+}

--- a/app/Mail/DocumentSubmitted.php
+++ b/app/Mail/DocumentSubmitted.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use App\Models\User;
+
+class DocumentSubmitted extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(public User $user)
+    {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Nouveau justificatif',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.document_submitted',
+            with: ['user' => $this->user],
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'document_valide',
+        'justificatif_path',
     ];
 
     /**

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -17,6 +17,8 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->boolean('document_valide')->default(false);
+            $table->string('justificatif_path')->nullable();
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -18,6 +18,7 @@ class DemoSeeder extends Seeder
             'name' => 'Utilisateur Démo',
             'email' => 'demo@example.com',
             'password' => bcrypt('password'),
+            'document_valide' => true,
         ]);
 
         Property::create([

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -1,29 +1,42 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="max-w-4xl mx-auto p-4">
-    <h1 class="text-2xl font-bold mb-4">Administration</h1>
+<div class="container py-4">
+    <h1 class="h4 mb-4">Administration</h1>
 
-    <h2 class="text-xl font-bold mt-4">Utilisateurs</h2>
-    <ul class="list-disc pl-5">
+    <h2 class="h5 mt-4">Utilisateurs</h2>
+    <ul class="ps-3">
         @foreach($users as $user)
-            <li>{{ $user->name }} - {{ $user->email }}</li>
+            <li>
+                {{ $user->name }} - {{ $user->email }}
+                @if($user->justificatif_path)
+                    <a href="{{ asset('storage/'.$user->justificatif_path) }}" target="_blank">Justificatif</a>
+                    @if(!$user->document_valide)
+                        <form action="{{ route('admin.validate', $user) }}" method="POST" class="d-inline">
+                            @csrf
+                            <button class="btn btn-sm btn-success">Valider</button>
+                        </form>
+                    @else
+                        <span class="badge bg-success">Validé</span>
+                    @endif
+                @endif
+            </li>
         @endforeach
     </ul>
 
-    <h2 class="text-xl font-bold mt-4">Enchères</h2>
-    <ul class="list-disc pl-5">
+    <h2 class="h5 mt-4">Enchères</h2>
+    <ul class="ps-3">
         @foreach($bids as $bid)
             <li>{{ $bid->user->name }} - {{ number_format($bid->amount,0,',',' ') }} € - {{ $bid->created_at->format('d/m/Y H:i') }}</li>
         @endforeach
     </ul>
 
-    <h2 class="text-xl font-bold mt-4">Vente</h2>
+    <h2 class="h5 mt-4">Vente</h2>
     <p>Status : {{ $property->closed ? 'Terminée' : 'En cours' }}</p>
     @if(!$property->closed)
     <form action="{{ route('admin.close') }}" method="POST">
         @csrf
-        <button type="submit" class="mt-2 px-4 py-2 bg-red-600 text-white">Clore la vente</button>
+        <button type="submit" class="btn btn-danger mt-2">Clore la vente</button>
     </form>
     @endif
 </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,43 +1,25 @@
-<x-guest-layout>
-    <!-- Session Status -->
-    <x-auth-session-status class="mb-4" :status="session('status')" />
+@extends('layouts.guest')
 
-    <form method="POST" action="{{ route('login') }}">
-        @csrf
-
-        <!-- Adresse email -->
-        <div>
-            <x-input-label for="email" value="Email" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
-            <x-input-error :messages="$errors->get('email')" class="mt-2" />
-        </div>
-
-        <!-- Mot de passe -->
-        <div class="mt-4">
-            <x-input-label for="password" value="Mot de passe" />
-
-            <x-text-input id="password" class="block mt-1 w-full"
-                            type="password"
-                            name="password"
-                            required autocomplete="current-password" />
-
-            <x-input-error :messages="$errors->get('password')" class="mt-2" />
-        </div>
-
-        <!-- Se souvenir de moi -->
-        <div class="block mt-4">
-            <label for="remember_me" class="inline-flex items-center">
-                <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" name="remember">
-                <span class="ms-2 text-sm text-gray-600">Se souvenir de moi</span>
-            </label>
-        </div>
-
-        <div class="flex items-center justify-end mt-4">
-            <span class="text-sm mr-4">Mot de passe perdu ? Contactez <a href="mailto:{{ config('mail.owner_address') }}" class="underline">l'administrateur</a>.</span>
-
-            <x-primary-button class="ms-3">
-                {{ __('Log in') }}
-            </x-primary-button>
-        </div>
-    </form>
-</x-guest-layout>
+@section('content')
+<form method="POST" action="{{ route('login') }}">
+    @csrf
+    <div class="mb-3">
+        <label for="email" class="form-label">Email</label>
+        <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required autofocus>
+        @error('email')<div class="text-danger">{{ $message }}</div>@enderror
+    </div>
+    <div class="mb-3">
+        <label for="password" class="form-label">Mot de passe</label>
+        <input id="password" type="password" class="form-control" name="password" required>
+        @error('password')<div class="text-danger">{{ $message }}</div>@enderror
+    </div>
+    <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" name="remember" id="remember">
+        <label class="form-check-label" for="remember">Se souvenir de moi</label>
+    </div>
+    <div class="mb-3 text-end">
+        <span class="small">Mot de passe perdu ? Contactez <a href="mailto:{{ config('mail.owner_address') }}">l'administrateur</a>.</span>
+    </div>
+    <button type="submit" class="btn btn-primary w-100">Se connecter</button>
+</form>
+@endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,52 +1,28 @@
-<x-guest-layout>
-    <form method="POST" action="{{ route('register') }}">
-        @csrf
+@extends('layouts.guest')
 
-        <!-- Nom -->
-        <div>
-            <x-input-label for="name" value="Nom" />
-            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
-            <x-input-error :messages="$errors->get('name')" class="mt-2" />
-        </div>
-
-        <!-- Adresse email -->
-        <div class="mt-4">
-            <x-input-label for="email" value="Email" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="username" />
-            <x-input-error :messages="$errors->get('email')" class="mt-2" />
-        </div>
-
-        <!-- Mot de passe -->
-        <div class="mt-4">
-            <x-input-label for="password" value="Mot de passe" />
-
-            <x-text-input id="password" class="block mt-1 w-full"
-                            type="password"
-                            name="password"
-                            required autocomplete="new-password" />
-
-            <x-input-error :messages="$errors->get('password')" class="mt-2" />
-        </div>
-
-        <!-- Confirmation du mot de passe -->
-        <div class="mt-4">
-            <x-input-label for="password_confirmation" value="Confirmez le mot de passe" />
-
-            <x-text-input id="password_confirmation" class="block mt-1 w-full"
-                            type="password"
-                            name="password_confirmation" required autocomplete="new-password" />
-
-            <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
-        </div>
-
-        <div class="flex items-center justify-end mt-4">
-            <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('login') }}">
-                Déjà inscrit ?
-            </a>
-
-            <x-primary-button class="ms-4">
-                S'inscrire
-            </x-primary-button>
-        </div>
-    </form>
-</x-guest-layout>
+@section('content')
+<form method="POST" action="{{ route('register') }}">
+    @csrf
+    <div class="mb-3">
+        <label for="name" class="form-label">Nom</label>
+        <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}" required autofocus>
+        @error('name')<div class="text-danger">{{ $message }}</div>@enderror
+    </div>
+    <div class="mb-3">
+        <label for="email" class="form-label">Email</label>
+        <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required>
+        @error('email')<div class="text-danger">{{ $message }}</div>@enderror
+    </div>
+    <div class="mb-3">
+        <label for="password" class="form-label">Mot de passe</label>
+        <input id="password" type="password" class="form-control" name="password" required>
+        @error('password')<div class="text-danger">{{ $message }}</div>@enderror
+    </div>
+    <div class="mb-3">
+        <label for="password_confirmation" class="form-label">Confirmez le mot de passe</label>
+        <input id="password_confirmation" type="password" class="form-control" name="password_confirmation" required>
+    </div>
+    <button type="submit" class="btn btn-primary w-100">S'inscrire</button>
+    <p class="mt-3 text-center"><a href="{{ route('login') }}">Déjà inscrit ?</a></p>
+</form>
+@endsection

--- a/resources/views/document/upload.blade.php
+++ b/resources/views/document/upload.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <h1 class="h4 mb-4">Justificatif de solvabilité</h1>
+
+    @if(session('status') === 'document-submitted')
+        <div class="alert alert-success">Document envoyé. Il sera vérifié prochainement.</div>
+    @endif
+
+    @if($user->justificatif_path)
+        <p>Document actuel : <a href="{{ asset('storage/'.$user->justificatif_path) }}" target="_blank">voir le fichier</a></p>
+        <p class="{{ $user->document_valide ? 'text-success' : 'text-warning' }}">
+            {{ $user->document_valide ? 'Validé' : 'En attente de validation' }}
+        </p>
+    @endif
+
+    <form action="{{ route('document.store') }}" method="POST" enctype="multipart/form-data">
+        @csrf
+        <div class="mb-3">
+            <label for="justificatif" class="form-label">Choisir un fichier (PDF ou image)</label>
+            <input type="file" name="justificatif" id="justificatif" class="form-control" required>
+            @error('justificatif')<div class="text-danger">{{ $message }}</div>@enderror
+        </div>
+        <button type="submit" class="btn btn-primary">Envoyer</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/emails/document_submitted.blade.php
+++ b/resources/views/emails/document_submitted.blade.php
@@ -1,0 +1,12 @@
+<x-mail::message>
+# Nouveau justificatif soumis
+
+L'utilisateur {{ $user->name }} ({{ $user->email }}) a envoyé un justificatif de solvabilité.
+
+<x-mail::button :url="url('/admin')">
+Voir le tableau de bord
+</x-mail::button>
+
+Merci,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,15 +7,11 @@
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
-
-        <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     </head>
-    <body class="font-sans antialiased">
-        <div class="min-h-screen bg-gray-100">
+    <body>
+        <div class="min-vh-100 bg-light">
             @include('layouts.navigation')
 
             <!-- Page Heading -->
@@ -32,7 +28,7 @@
                 @yield('content')
                 {{ $slot ?? '' }}
             </main>
-            <footer class="text-center py-4 text-sm text-gray-600">
+            <footer class="text-center py-4 small text-muted">
                 <a href="{{ url('/mentions-legales') }}" class="underline">Mentions légales</a> |
                 <a href="{{ url('/conditions') }}" class="underline">Conditions d'utilisation</a>
                 <div>Contact : {{ config('mail.owner_address') }}</div>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -7,23 +7,21 @@
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
-
-        <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     </head>
-    <body class="font-sans text-gray-900 antialiased">
-        <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">
+    <body>
+        <div class="min-vh-100 d-flex flex-column justify-content-center align-items-center bg-light py-5">
             <div>
                 <a href="/">
                     <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
                 </a>
             </div>
 
-            <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
-                {{ $slot }}
+            <div class="w-100" style="max-width: 400px;">
+                <div class="card p-4">
+                    @yield('content')
+                </div>
             </div>
         </div>
     </body>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,100 +1,34 @@
-<nav x-data="{ open: false }" class="bg-white border-b border-gray-100">
-    <!-- Primary Navigation Menu -->
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
-            <div class="flex">
-                <!-- Logo -->
-                <div class="shrink-0 flex items-center">
-                    <a href="{{ route('dashboard') }}">
-                        <x-application-logo class="block h-9 w-auto fill-current text-gray-800" />
-                    </a>
-                </div>
-
-                <!-- Navigation Links -->
-                <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                        {{ __('Dashboard') }}
-                    </x-nav-link>
-                </div>
-            </div>
-
-            <!-- Settings Dropdown -->
-            <div class="hidden sm:flex sm:items-center sm:ms-6">
-                <x-dropdown align="right" width="48">
-                    <x-slot name="trigger">
-                        <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
-                            <div>{{ Auth::user()->name }}</div>
-
-                            <div class="ms-1">
-                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                </svg>
-                            </div>
-                        </button>
-                    </x-slot>
-
-                    <x-slot name="content">
-                        <x-dropdown-link :href="route('profile.edit')">
-                            {{ __('Profile') }}
-                        </x-dropdown-link>
-
-                        <!-- Authentication -->
-                        <form method="POST" action="{{ route('logout') }}">
-                            @csrf
-
-                            <x-dropdown-link :href="route('logout')"
-                                    onclick="event.preventDefault();
-                                                this.closest('form').submit();">
-                                {{ __('Log Out') }}
-                            </x-dropdown-link>
-                        </form>
-                    </x-slot>
-                </x-dropdown>
-            </div>
-
-            <!-- Hamburger -->
-            <div class="-me-2 flex items-center sm:hidden">
-                <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
-                    <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                        <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-    </div>
-
-    <!-- Responsive Navigation Menu -->
-    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
-        <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                {{ __('Dashboard') }}
-            </x-responsive-nav-link>
-        </div>
-
-        <!-- Responsive Settings Options -->
-        <div class="pt-4 pb-1 border-t border-gray-200">
-            <div class="px-4">
-                <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
-                <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
-            </div>
-
-            <div class="mt-3 space-y-1">
-                <x-responsive-nav-link :href="route('profile.edit')">
-                    {{ __('Profile') }}
-                </x-responsive-nav-link>
-
-                <!-- Authentication -->
-                <form method="POST" action="{{ route('logout') }}">
-                    @csrf
-
-                    <x-responsive-nav-link :href="route('logout')"
-                            onclick="event.preventDefault();
-                                        this.closest('form').submit();">
-                        {{ __('Log Out') }}
-                    </x-responsive-nav-link>
-                </form>
-            </div>
+<nav class="navbar navbar-expand-lg navbar-light bg-white mb-3 border-bottom">
+    <div class="container">
+        <a class="navbar-brand" href="/">{{ config('app.name') }}</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMain" aria-controls="navMain" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navMain">
+            <ul class="navbar-nav ms-auto">
+                @guest
+                    <li class="nav-item"><a class="nav-link" href="{{ route('login') }}">Se connecter</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ route('register') }}">S'inscrire</a></li>
+                @else
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">{{ Auth::user()->name }}</a>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="{{ route('profile.edit') }}">Profil</a></li>
+                            <li><a class="dropdown-item" href="{{ route('document.form') }}">Justificatif</a></li>
+                            @if(Auth::user()->email === config('mail.admin_address'))
+                                <li><a class="dropdown-item" href="{{ route('admin.index') }}">Admin</a></li>
+                            @endif
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                <form method="POST" action="{{ route('logout') }}">
+                                    @csrf
+                                    <button type="submit" class="dropdown-item">Se déconnecter</button>
+                                </form>
+                            </li>
+                        </ul>
+                    </li>
+                @endguest
+            </ul>
         </div>
     </div>
 </nav>

--- a/resources/views/property/show.blade.php
+++ b/resources/views/property/show.blade.php
@@ -1,29 +1,32 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="max-w-4xl mx-auto p-4">
-    <h1 class="text-2xl font-bold mb-4">{{ $property->title }}</h1>
+<div class="container py-4">
+    <h1 class="h4 mb-4">{{ $property->title }}</h1>
     <p class="mb-2">{{ $property->description }}</p>
     <p class="mb-2"><strong>Lieu :</strong> {{ $property->location }}</p>
     <p class="mb-2"><strong>Fin des enchères :</strong> {{ $property->end_at->format('d/m/Y H:i') }}</p>
     <p class="mb-4"><strong>Enchère actuelle :</strong> {{ $highestBid ? number_format($highestBid->amount,0,',',' ') . ' €' : 'Aucune' }}</p>
 
     @auth
-        @if(!$property->closed && $property->end_at->isFuture())
-        <form action="{{ route('bid.store') }}" method="POST" class="mb-4">
+        @if(!Auth::user()->document_valide)
+            <p class="alert alert-warning">Vous devez fournir un justificatif de solvabilité pour participer à l’enchère.</p>
+            <a href="{{ route('document.form') }}" class="btn btn-primary">Envoyer un justificatif</a>
+        @elseif(!$property->closed && $property->end_at->isFuture())
+        <form action="{{ route('bid.store') }}" method="POST" class="mb-4 mt-3">
             @csrf
-            <label for="amount" class="block mb-2">Montant de l'enchère (min {{ number_format(($highestBid?->amount ?? $property->starting_price - $property->min_increment) + $property->min_increment,0,',',' ') }} €)</label>
-            <input type="number" name="amount" id="amount" required class="border p-2" />
-            <button type="submit" class="ml-2 px-4 py-2 bg-blue-500 text-white">Enchérir</button>
+            <label for="amount" class="form-label">Montant de l'enchère (min {{ number_format(($highestBid?->amount ?? $property->starting_price - $property->min_increment) + $property->min_increment,0,',',' ') }} €)</label>
+            <input type="number" name="amount" id="amount" required class="form-control d-inline w-auto" />
+            <button type="submit" class="btn btn-success ms-2">Enchérir</button>
         </form>
         @else
-            <p class="text-red-600 font-bold">La vente est terminée.</p>
+            <p class="text-danger fw-bold">La vente est terminée.</p>
         @endif
     @else
-        <p><a href="{{ route('login') }}" class="text-blue-500 underline">Connectez-vous</a> pour enchérir.</p>
+        <p><a href="{{ route('login') }}" class="text-decoration-underline">Connectez-vous</a> pour enchérir.</p>
     @endauth
 
-    <h2 class="text-xl font-bold mt-8 mb-2">Historique des enchères</h2>
+    <h2 class="h5 mt-4 mb-2">Historique des enchères</h2>
     <div id="bids">
         @foreach($property->bids()->with('user')->orderByDesc('created_at')->get() as $bid)
             <p>{{ $bid->user->name }} - {{ number_format($bid->amount,0,',',' ') }} € - {{ $bid->created_at->format('d/m/Y H:i') }}</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,16 +4,22 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PropertyController;
 use App\Http\Controllers\BidController;
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\DocumentController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [PropertyController::class, 'show'])->name('property.show');
 Route::get('/bids', [PropertyController::class, 'bids'])->name('property.bids');
 Route::post('/bid', [BidController::class, 'store'])->middleware('auth')->name('bid.store');
+Route::middleware('auth')->group(function () {
+    Route::get('/justificatif', [DocumentController::class, 'show'])->name('document.form');
+    Route::post('/justificatif', [DocumentController::class, 'store'])->name('document.store');
+});
 Route::view('/mentions-legales', 'mentions-legales');
 Route::view('/conditions', 'conditions');
 
 Route::get('/admin', [AdminController::class, 'index'])->name('admin.index');
 Route::post('/admin/close', [AdminController::class, 'close'])->name('admin.close');
+Route::post('/admin/users/{user}/validate', [AdminController::class, 'validateDocument'])->name('admin.validate');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
## Summary
- add solvency document upload controller and mail
- store document path and validation status on users
- notify admin when a document is submitted
- restrict bidding unless user's document is validated
- convert layouts and pages to Bootstrap 5
- provide admin ability to validate documents
- adjust seed data and README

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657e30ffec83248d7b0fdbf7b51779