### PR TITLE
Add secure admin page with user management

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -33,7 +33,7 @@ class AdminController extends Controller
 
     private function authorizeAdmin(): void
     {
-        if (Auth::guest() || Auth::user()->email !== config('mail.admin_address')) {
+        if (Auth::guest() || !Auth::user()->is_admin) {
             abort(403);
         }
     }

--- a/app/Http/Middleware/IsAdmin.php
+++ b/app/Http/Middleware/IsAdmin.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class IsAdmin
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (auth()->check() && auth()->user()->is_admin) {
+            return $next($request);
+        }
+
+        abort(403, 'Accès refusé');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,6 +25,7 @@ class User extends Authenticatable
         'password',
         'phone_number',
         'proof_path',
+        'is_admin',
     ];
 
     /**
@@ -47,6 +48,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,6 +14,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'admin' => \App\Http\Middleware\Admin::class,
             'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+            'isAdmin' => \App\Http\Middleware\IsAdmin::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -4,12 +4,33 @@
 <div class="max-w-4xl mx-auto p-4">
     <h1 class="text-2xl font-bold mb-4">Administration</h1>
 
+    @php use Illuminate\Support\Facades\Storage; @endphp
+
     <h2 class="text-xl font-bold mt-4">Utilisateurs</h2>
-    <ul class="list-disc pl-5">
-        @foreach($users as $user)
-            <li>{{ $user->name }} - {{ $user->email }}</li>
-        @endforeach
-    </ul>
+    <table class="min-w-full text-left border-collapse">
+        <thead>
+            <tr>
+                <th class="border-b p-2">Nom / Email</th>
+                <th class="border-b p-2">Téléphone</th>
+                <th class="border-b p-2">Justificatif</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($users as $user)
+                <tr>
+                    <td class="border-b p-2">{{ $user->name ?? $user->email }}</td>
+                    <td class="border-b p-2">{{ $user->phone_number }}</td>
+                    <td class="border-b p-2">
+                        @if($user->proof_path)
+                            <a href="{{ Storage::url($user->proof_path) }}" class="text-indigo-600 underline">Télécharger</a>
+                        @else
+                            -
+                        @endif
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
 
     <h2 class="text-xl font-bold mt-4">Offres</h2>
     <ul class="list-disc pl-5">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,13 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    @auth
+                        @if(Auth::user()->is_admin)
+                            <x-nav-link :href="route('admin.index')" :active="request()->routeIs('admin.index')">
+                                Admin
+                            </x-nav-link>
+                        @endif
+                    @endauth
                 </div>
             </div>
 
@@ -74,6 +81,13 @@
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
+            @auth
+                @if(Auth::user()->is_admin)
+                    <x-responsive-nav-link :href="route('admin.index')" :active="request()->routeIs('admin.index')">
+                        Admin
+                    </x-responsive-nav-link>
+                @endif
+            @endauth
         </div>
 
         <!-- Responsive Settings Options -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,8 +17,10 @@ Route::get('/dashboard', function () {
 })->middleware(['auth'])->name('dashboard');
 
 
-Route::get('/admin', [AdminController::class, 'index'])->name('admin.index');
-Route::post('/admin/close', [AdminController::class, 'close'])->name('admin.close');
+Route::middleware(['auth', 'isAdmin'])->group(function () {
+    Route::get('/admin', [AdminController::class, 'index'])->name('admin.index');
+    Route::post('/admin/close', [AdminController::class, 'close'])->name('admin.close');
+});
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
@@ -35,8 +37,5 @@ Route::post('/register', [RegisteredUserController::class, 'store'])
 
 
 
-Route::middleware(['auth', 'admin'])->group(function () {
-    Route::get('/__backpanel_secret', [AdminController::class, 'index'])->name('admin.panel');
-});
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- create `IsAdmin` middleware and register alias
- gate `/admin` routes via new middleware
- list users with phone and proof download on admin page
- add admin link in navbar for admins
- make `User::$fillable` and casts aware of `is_admin`

## Testing
- `composer install` *(fails: requires ext-dom prior to install; after installing php-xml)*
- `./vendor/bin/phpunit` *(fails: some notifications expected)*

------
https://chatgpt.com/codex/tasks/task_e_68684fc99ea883248f9fafa35d38e3d5