### PR TITLE
Fix navbar dropdown and registration validation

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -30,13 +30,19 @@ class RegisteredUserController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
-            'phone_number' => ['required', 'string', 'max:20'],
-            'proof' => ['required', 'file', 'max:5120', 'mimes:pdf,jpg,png'],
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
-        ]);
+        $request->validate(
+            [
+                'name' => ['required', 'string', 'max:255'],
+                'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:' . User::class],
+                'phone_number' => ['required', 'regex:/^0[1-9][0-9]{8}$/'],
+                'proof' => ['required', 'file', 'max:5120', 'mimes:pdf,jpg,png'],
+                'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            ],
+            [
+                'email.email' => 'Veuillez saisir une adresse e-mail valide (ex: nom@domaine.com)',
+                'phone_number.regex' => 'Le numéro doit commencer par 0 et contenir exactement 10 chiffres. Exemple : 0612345678',
+            ]
+        );
 
         $path = $request->file('proof')->store('public/proofs');
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -12,14 +12,35 @@
         <!-- Adresse email -->
         <div class="mt-4">
             <x-input-label for="email" value="Email" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="username" />
+            <x-text-input
+                id="email"
+                class="block mt-1 w-full"
+                type="email"
+                name="email"
+                :value="old('email')"
+                required
+                autocomplete="username"
+                oninvalid="this.setCustomValidity('Veuillez saisir une adresse e-mail valide (ex: nom@domaine.com)')"
+                oninput="this.setCustomValidity('')"
+            />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 
         <!-- Téléphone -->
         <div class="mt-4">
             <x-input-label for="phone_number" value="Téléphone" />
-            <x-text-input id="phone_number" class="block mt-1 w-full" type="text" name="phone_number" :value="old('phone_number')" required />
+            <x-text-input
+                id="phone_number"
+                class="block mt-1 w-full"
+                type="text"
+                name="phone_number"
+                :value="old('phone_number')"
+                required
+                pattern="^0[1-9][0-9]{8}$"
+                inputmode="tel"
+                oninvalid="this.setCustomValidity('Le numéro doit commencer par 0 et contenir exactement 10 chiffres. Exemple : 0612345678')"
+                oninput="this.setCustomValidity('')"
+            />
             <x-input-error :messages="$errors->get('phone_number')" class="mt-2" />
         </div>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -68,6 +68,7 @@
             </main>
             <footer class="text-center py-4 text-sm text-gray-600">
             <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
             <script>
                 document.addEventListener('DOMContentLoaded', function () {
                     const lightbox = GLightbox({

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -18,10 +18,10 @@
         <div class="d-flex align-items-center">
             @auth
                 <div class="dropdown">
-                    <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                    <button id="userDropdown" class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-haspopup="true">
                         {{ Auth::user()->name }}
                     </button>
-                    <ul class="dropdown-menu dropdown-menu-end">
+                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
                         <li><a class="dropdown-item" href="{{ route('profile.edit') }}">Profil</a></li>
                         <li>
                             <form method="POST" action="{{ route('logout') }}">


### PR DESCRIPTION
## Summary
- validate phone numbers with regex and show helpful messages
- include Bootstrap JS for working dropdown menu
- improve dropdown accessibility
- revert locale changes handled elsewhere

## Testing
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686975a78d24832494dab95b40df49e3